### PR TITLE
Float values are not handled by Mike

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ init:
 	pip install -e .[dev]
 
 test:
-	pytest -v
+	pytest -vv
 
 lint:
 	pylint mycroft_holmes
@@ -12,7 +12,7 @@ lint:
 coverage:
 	rm -f .coverage*
 	rm -rf htmlcov/*
-	coverage run -p -m pytest -v
+	coverage run -p -m pytest -vv
 	coverage combine
 	coverage html -d htmlcov $(coverage_options)
 	coverage xml -i

--- a/mycroft_holmes/sources/analytics.py
+++ b/mycroft_holmes/sources/analytics.py
@@ -173,7 +173,7 @@ class GoogleAnalyticsSource(SourceBase):
 
             # [{'metrics': [{'values': ['270634']}], 'dimensions': ['20181213']}]
             rows = report['data']['rows']
-            return int(rows[0]['metrics'][0]['values'][0])
+            return int(float(rows[0]['metrics'][0]['values'][0]))
 
         except Exception as ex:
             self.logger.error('get_value() failed', exc_info=True)


### PR DESCRIPTION
Resolves #40

```
mycroft_holmes.errors.MycroftSourceError: Failed to get metric value: ValueError("invalid literal for int() with base 10: '42.857142857142854'")
```