### PR TITLE
Add http/xpath source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.6-alpine3.9
 
 # label the image with branch name and commit hash
 LABEL maintainer="maciej.brencz@gmail.com"
@@ -15,7 +15,7 @@ ADD mycroft_holmes/__init__.py mycroft_holmes/
 ADD mycroft_holmes/bin mycroft_holmes/bin
 
 RUN apk add --update --no-cache mariadb-connector-c \
-    && apk add --no-cache --virtual .build-deps build-base mariadb-dev libffi-dev yaml-dev \
+    && apk add --no-cache --virtual .build-deps build-base mariadb-dev libffi-dev yaml-dev libxml2-dev libxslt-dev \
     && pip install -e . \
     && apk del .build-deps
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine3.9
+FROM python:3.6-slim
 
 # label the image with branch name and commit hash
 LABEL maintainer="maciej.brencz@gmail.com"
@@ -14,10 +14,10 @@ ADD setup.py .
 ADD mycroft_holmes/__init__.py mycroft_holmes/
 ADD mycroft_holmes/bin mycroft_holmes/bin
 
-RUN apk add --update --no-cache mariadb-connector-c \
-    && apk add --no-cache --virtual .build-deps build-base mariadb-dev libffi-dev yaml-dev libxml2-dev libxslt-dev \
+RUN apt-get update && apt-get install -y libmariadbclient-dev gcc \
     && pip install -e . \
-    && apk del .build-deps
+    && rm -rf ~/.cache/pip \
+    && apt-get remove -y gcc && apt-get autoremove -y
 
 # copy the rest of the files
 ADD . .

--- a/example.yaml
+++ b/example.yaml
@@ -1,3 +1,7 @@
+# Run the following command to see how metrics defined below are collected:
+#
+# MIKE_CONFIG=example.yaml collect_metrics
+
 # dashboard name
 name: "The Example dashboard"
 
@@ -14,14 +18,26 @@ storage:
   password: ''
 
 # now define metrics that are taken from sources above
-metrics: []
+metrics:
+  - name: lubimy_czytac/rating
+    source: http/xpath  # use the base source directly here
+    url: "http://lubimyczytac.pl/ksiazka/{book_id}"
+    xpath: '//*[@itemprop="aggregateRating"]//*[@itemprop="ratingValue"]'
+    label: "Book rating: %d"
+
+# these keys will be copied to each feature defined below
+common:
+  metrics:
+    -  name: lubimy_czytac/rating
 
 # now features "score" will be calculated using the metrics defined above with per-feature parameters set
 features:
-  - name: Foo Bar
-    url: http://docs.company.net/pages/FooBar
-    repo: https://github.com/foo/bar
-    metrics:
-    - name: foo/weighted-bar
-      source: common/const
-      weight: 700
+    - name: PanTadeusz
+      url: "http://lubimyczytac.pl/ksiazka/4871036/pan-tadeusz"
+      template:
+        book_id: 4871036
+
+    - name: "Wojna i Pókój"
+      url: "http://lubimyczytac.pl/ksiazka/4869384/wojna-i-pokoj-tom-1"
+      template:
+        book_id: 4869384

--- a/example.yaml
+++ b/example.yaml
@@ -24,6 +24,11 @@ metrics:
     url: "http://lubimyczytac.pl/ksiazka/{book_id}"
     xpath: '//*[@itemprop="aggregateRating"]//*[@itemprop="ratingValue"]'
     label: "Book rating: %d"
+  - name: lubimy_czytac/wants_to_read
+    source: http/xpath  # use the base source directly here
+    url: "http://lubimyczytac.pl/ksiazka/{book_id}"
+    xpath: '//*[@id="ajaxShelfsBox"]//*[@data-shelf-id-counter="3"]'
+    label: "Wants to read: %d"
 
 # these keys will be copied to each feature defined below
 common:
@@ -36,6 +41,9 @@ features:
       url: "http://lubimyczytac.pl/ksiazka/4871036/pan-tadeusz"
       template:
         book_id: 4871036
+      metrics:
+        # additional metric just for this book
+        - name: lubimy_czytac/wants_to_read
 
     - name: "Wojna i Pókój"
       url: "http://lubimyczytac.pl/ksiazka/4869384/wojna-i-pokoj-tom-1"

--- a/mycroft_holmes/sources/README.md
+++ b/mycroft_holmes/sources/README.md
@@ -296,7 +296,7 @@ Source name: `http/xpath`
       # http://lubimyczytac.pl/ksiazka/4871036/pan-tadeusz
       - name: PanTadeusz
         template:
-          - book_id: 4871036
+          book_id: 4871036
         metrics:
           - name: lubimy_czytac/rating
 ```

--- a/mycroft_holmes/sources/README.md
+++ b/mycroft_holmes/sources/README.md
@@ -19,6 +19,7 @@ This directory contains implementation of various sources that provide values fo
 * `common/jira`: Returns a number of Jira ticket matching given JQL query.
 * `common/logstash`: Returns a number of entries matching a given elasticsearch query.
 * `common/mysql`: Returns a number result for a given SQL query.
+* `http/xpath`: Makes a HTTP request to fetch HTML and takes a node using xpath query.
 
 ### TODO
 
@@ -262,6 +263,42 @@ Please note that only the first column from the first row in the results set wil
           - user_group: "Admin"  # this will be used in query defined above
         metrics:
           -  name: users/count
+```
+
+### HttpXPathSource
+
+Source name: `http/xpath`
+
+> Makes a HTTP request to fetch HTML and takes a node using xpath query.
+
+#### `sources` config
+
+> Not applicable. This source does not have any specific settings.
+
+#### `metrics` config
+
+```yaml
+    metrics:
+      - name: lubimy_czytac/rating
+        source: http/xpath  # use the base source directly here
+        url: "http://lubimyczytac.pl/ksiazka/{book_id}"
+        xpath: '//*[@itemprop="aggregateRating"]//*[@itemprop="ratingValue"]'
+        label: "Book rating: %d"
+```
+
+> Please refer to [XPath documentation](https://developer.mozilla.org/en-US/docs/Web/XPath)
+> for how to specify the `xpath` parameter.
+
+#### `features` config
+
+```yaml
+    features:
+      # http://lubimyczytac.pl/ksiazka/4871036/pan-tadeusz
+      - name: PanTadeusz
+        template:
+          - book_id: 4871036
+        metrics:
+          - name: lubimy_czytac/rating
 ```
 
 ## Sources setup

--- a/mycroft_holmes/sources/__init__.py
+++ b/mycroft_holmes/sources/__init__.py
@@ -4,6 +4,7 @@ Your sources needs to be listed here to allow their discovery by SourceBase clas
 from .analytics import GoogleAnalyticsSource
 from .athena import AthenaSource
 from .const import ConstSource
+from .http.xpath import HttpXPathSource
 from .jira import JiraSource
 from .logstash import LogstashSource
 from .mysql import MysqlSource

--- a/mycroft_holmes/sources/http/xpath.py
+++ b/mycroft_holmes/sources/http/xpath.py
@@ -68,7 +68,7 @@ class HttpXPathSource(SourceBase):
     def get_value(self, **kwargs):
         """
         :raise: MycroftSourceError
-        :rtype: int
+        :rtype: float
         """
         url = self.get_url(**kwargs)
         xpath = kwargs.get('xpath')
@@ -99,7 +99,7 @@ class HttpXPathSource(SourceBase):
             text = str(matches[0].text).strip()
             text = text.replace(",", ".")
 
-            return int(float(text))
+            return float(text)
 
         except Exception as ex:
             raise MycroftSourceError('Failed to get metric value: %s' % repr(ex))

--- a/mycroft_holmes/sources/http/xpath.py
+++ b/mycroft_holmes/sources/http/xpath.py
@@ -1,0 +1,111 @@
+"""
+http/xpath source
+"""
+from lxml.html import document_fromstring
+from requests import session
+
+from mycroft_holmes.errors import MycroftSourceError
+from mycroft_holmes.utils import format_query
+
+from ..base import SourceBase
+
+
+class HttpXPathSource(SourceBase):
+    """
+    Makes a HTTP request to fetch HTML and takes a node using xpath query.
+
+    #### `sources` config
+
+    > Not applicable. This source does not have any specific settings.
+
+    #### `metrics` config
+
+    ```yaml
+        metrics:
+          - name: lubimy_czytac/rating
+            source: http/xpath  # use the base source directly here
+            url: "http://lubimyczytac.pl/ksiazka/{book_id}"
+            xpath: '//*[@itemprop="aggregateRating"]//*[@itemprop="ratingValue"]'
+            label: "Book rating: %d"
+    ```
+
+    > Please refer to [XPath documentation](https://developer.mozilla.org/en-US/docs/Web/XPath)
+    > for how to specify the `xpath` parameter.
+
+    #### `features` config
+
+    ```yaml
+        features:
+          # http://lubimyczytac.pl/ksiazka/4871036/pan-tadeusz
+          - name: PanTadeusz
+            template:
+              - book_id: 4871036
+            metrics:
+              - name: lubimy_czytac/rating
+    ```
+    """
+
+    NAME = 'http/xpath'
+
+    def __init__(self, client=None):
+        """
+        :type client obj
+        """
+        super(HttpXPathSource, self).__init__()
+
+        self._client = client or session()
+
+    @staticmethod
+    def get_url(**kwargs):
+        """
+        :type: dict
+        :rtype: str|None
+        """
+        url = kwargs.get('url')
+        return format_query(url, kwargs.get('template')) if url else None
+
+    def get_value(self, **kwargs):
+        """
+        :raise: MycroftSourceError
+        :rtype: int
+        """
+        url = self.get_url(**kwargs)
+        xpath = kwargs.get('xpath')
+
+        assert isinstance(url, str), '"url" parameter needs to be provided'
+        assert isinstance(xpath, str), '"xpath" parameter needs to be provided'
+
+        self.logger.info('Fetching <%s>', url)
+
+        try:
+            resp = self._client.get(url)
+            resp.raise_for_status()
+
+            self.logger.info('GET <%s> - HTTP %d (%.2f kB)',
+                             url, resp.status_code, 1. * len(resp.text) / 1024)
+
+            # parse with lxml
+            # https://lxml.de/lxmlhtml.html#parsing-html
+            self.logger.info('Parsing HTML and querying it with "%s" xpath', xpath)
+
+            node = document_fromstring(resp.text)
+            matches = node.xpath(xpath)
+
+            if not matches:
+                raise MycroftSourceError('xpath query returned no matches')
+
+            return int(matches[0].text)
+
+        except Exception as ex:
+            raise MycroftSourceError('Failed to get metric value: %s' % repr(ex))
+
+    def get_more_link(self, **kwargs):
+        """
+        Returns a tuple with link name and URL that this metric fetches
+
+        :rtype: tuple[str, str]|None
+        """
+        return (
+            'Visit the page',
+            self.get_url(** kwargs)
+        )

--- a/mycroft_holmes/sources/http/xpath.py
+++ b/mycroft_holmes/sources/http/xpath.py
@@ -95,7 +95,11 @@ class HttpXPathSource(SourceBase):
             if not matches:
                 raise MycroftSourceError('xpath query returned no matches')
 
-            return int(matches[0].text)
+            # "123,5" - do our best to parse such value
+            text = str(matches[0].text).strip()
+            text = text.replace(",", ".")
+
+            return int(float(text))
 
         except Exception as ex:
             raise MycroftSourceError('Failed to get metric value: %s' % repr(ex))

--- a/mycroft_holmes/sources/http/xpath.py
+++ b/mycroft_holmes/sources/http/xpath.py
@@ -39,17 +39,18 @@ class HttpXPathSource(SourceBase):
           # http://lubimyczytac.pl/ksiazka/4871036/pan-tadeusz
           - name: PanTadeusz
             template:
-              - book_id: 4871036
+              book_id: 4871036
             metrics:
-              - name: lubimy_czytac/rating
+              name: lubimy_czytac/rating
     ```
     """
 
     NAME = 'http/xpath'
 
-    def __init__(self, client=None):
+    def __init__(self, client=None, **kwargs):
         """
         :type client obj
+        :type kwargs obj
         """
         super(HttpXPathSource, self).__init__()
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'PyAthena==1.4.4',
         'pyyaml>=4.2b1',
         'python-dotenv==0.10.1',
+        'lxml==4.3.0',
         # UI
         'flask==1.0.2',
         'gunicorn==19.9.0',

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -182,27 +182,14 @@ def test_config_get_metrics_for_feature_const():
 
 def test_minimal_config():
     config = Config(config_file=get_fixtures_directory() + '/../../example.yaml')
-    assert len(config.get_features()) == 1
+    assert len(config.get_features()) == 2
+    assert len(config.get_metrics()) == 1
 
     base.SOURCES_CACHE = dict()
-    metrics = config.get_metrics_for_feature('Foo Bar')
-
+    metrics = config.get_metrics_for_feature('PanTadeusz')
     print(metrics)
-    assert len(metrics) == 1
 
-    assert metrics[0].get_spec() == {
-        'name': 'foo/weighted-bar',
-        'source': 'common/const',
-        'weight': 700
-    }
-
-    assert metrics[0].get_source_name() == 'common/const'
-    assert metrics[0].get_weight() == 700
-
-    assert metrics[0].value == 1
-    assert metrics[0].get_label_with_value() is None
-    assert metrics[0].get_formatted_value() == '1'
+    assert metrics[0].get_source_name() == 'http/xpath'
 
     # can we handle empty entries in the config?
-    assert len(config.get_metrics()) == 0
     assert len(config.get_sources()) == 0

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -183,7 +183,7 @@ def test_config_get_metrics_for_feature_const():
 def test_minimal_config():
     config = Config(config_file=get_fixtures_directory() + '/../../example.yaml')
     assert len(config.get_features()) == 2
-    assert len(config.get_metrics()) == 1
+    assert len(config.get_metrics()) == 2
 
     base.SOURCES_CACHE = dict()
     metrics = config.get_metrics_for_feature('PanTadeusz')

--- a/test/test_source_http_xpath.py
+++ b/test/test_source_http_xpath.py
@@ -93,14 +93,14 @@ def test_invalid_xpath_and_no_matches():
         source.get_value(url=URL, xpath='hello!')
 
     print(ex)
-    assert str(ex).endswith("XPathEvalError('Invalid expression')")
+    assert "XPathEvalError('Invalid expression')" in str(ex)
 
     # xpath is valid, but there are no matches
     with raises(MycroftSourceError) as ex:
         source.get_value(url=URL, xpath='//h1')
 
     print(ex)
-    assert str(ex).endswith("MycroftSourceError('xpath query returned no matches')")
+    assert "MycroftSourceError('xpath query returned no matches')" in str(ex)
 
 
 def test_client_exception_handling():

--- a/test/test_source_http_xpath.py
+++ b/test/test_source_http_xpath.py
@@ -52,7 +52,7 @@ def get_source_with_mocked_client(mocked_client=None):
 
 
 URL = 'http://foo.bar/{path}'
-TEXT = '<p>foo bar<b>123</b></p>'
+TEXT = '<p>foo bar<b>\n123,5\n</b></p>'
 
 
 def test_is_source_present():

--- a/test/test_source_http_xpath.py
+++ b/test/test_source_http_xpath.py
@@ -78,7 +78,7 @@ def test_source_get_value():
     assert isinstance(source, HttpXPathSource)
     assert isinstance(source._client, HttpClient), 'client should be mocked'
 
-    assert source.get_value(**args) == 123
+    assert source.get_value(**args) == 123.5
 
     # URL should be properly filled with template values
     assert source._client.requested_url == 'http://foo.bar/get/foo'

--- a/test/test_source_http_xpath.py
+++ b/test/test_source_http_xpath.py
@@ -93,14 +93,14 @@ def test_invalid_xpath_and_no_matches():
         source.get_value(url=URL, xpath='hello!')
 
     print(ex)
-    assert "XPathEvalError('Invalid expression')" in str(ex)
+    assert "XPathEvalError('Invalid expression'" in str(ex)
 
     # xpath is valid, but there are no matches
     with raises(MycroftSourceError) as ex:
         source.get_value(url=URL, xpath='//h1')
 
     print(ex)
-    assert "MycroftSourceError('xpath query returned no matches')" in str(ex)
+    assert "MycroftSourceError('xpath query returned no matches'" in str(ex)
 
 
 def test_client_exception_handling():

--- a/test/test_source_http_xpath.py
+++ b/test/test_source_http_xpath.py
@@ -1,0 +1,115 @@
+"""
+Set of unit test for http/xpath source
+"""
+from pytest import raises
+
+from mycroft_holmes.errors import MycroftSourceError
+from mycroft_holmes.sources.base import SourceBase
+from mycroft_holmes.sources import HttpXPathSource
+
+
+class HttpResponse:
+    """
+    Mocked HTTP response
+    """
+    def __init__(self, text: str = None):
+        self.text = text
+        self.status_code = 200
+
+    def raise_for_status(self):
+        if self.text is None:
+            raise Exception('Mocked HTTP exception')
+
+
+class HttpClient:
+    """
+    Mocked requests class
+    """
+    def __init__(self, text: str = None):
+        self.response = HttpResponse(text)
+        self.requested_url: str = None
+
+    def get(self, url: str):
+        """
+        :type url str
+        :rtype: HttpResponse
+        """
+        self.requested_url = url
+        return self.response
+
+
+def get_source_with_mocked_client(mocked_client=None):
+    """
+    :type mocked_client HttpClient
+    :rtype: HttpXPathSource
+    """
+    return SourceBase.new_from_name(
+        source_name=HttpXPathSource.NAME,
+        args={
+            'client': mocked_client
+        }
+    )
+
+
+URL = 'http://foo.bar/{path}'
+TEXT = '<p>foo bar<b>123</b></p>'
+
+
+def test_is_source_present():
+    assert HttpXPathSource.NAME in SourceBase.get_sources_names()
+
+
+def test_source_get_value():
+    args = dict(
+        url=URL, xpath='//p/b', template={'path': 'get/foo'}
+    )
+
+    # exceptions handling
+    source = get_source_with_mocked_client(HttpClient(None))
+
+    # AssertionError: "url" parameter needs to be provided
+    with raises(MycroftSourceError):
+        source.get_value(url=URL, xpath='//p/b', template={'path': 'get/foo'})
+
+    # HTML parsing
+    source = get_source_with_mocked_client(HttpClient(TEXT))
+
+    print(source)
+    assert isinstance(source, HttpXPathSource)
+    assert isinstance(source._client, HttpClient), 'client should be mocked'
+
+    assert source.get_value(**args) == 123
+
+    # URL should be properly filled with template values
+    assert source._client.requested_url == 'http://foo.bar/get/foo'
+    assert source.get_more_link(**args) == ('Visit the page', 'http://foo.bar/get/foo')
+
+
+def test_invalid_xpath_and_no_matches():
+    source = get_source_with_mocked_client(HttpClient(TEXT))
+
+    # XPathEvalError
+    with raises(MycroftSourceError) as ex:
+        source.get_value(url=URL, xpath='hello!')
+
+    print(ex)
+    assert str(ex).endswith("XPathEvalError('Invalid expression')")
+
+    # xpath is valid, but there are no matches
+    with raises(MycroftSourceError) as ex:
+        source.get_value(url=URL, xpath='//h1')
+
+    print(ex)
+    assert str(ex).endswith("MycroftSourceError('xpath query returned no matches')")
+
+
+def test_client_exception_handling():
+    source = get_source_with_mocked_client()
+
+    # AssertionError: "url" parameter needs to be provided
+    with raises(AssertionError):
+        source.get_value(query='Foo')
+
+    # AssertionError: "xpath" parameter needs to be provided
+    with raises(AssertionError):
+        source.get_value(url='Foo')


### PR DESCRIPTION
Resolves #59

A simple yet working `example.yaml` is provided for #56.

## Dockefile

Mike now uses `python:slim` base image, because it takes soooooome time to build `lxml` and alpine is not compatible with Python wheels - docker-library/docs#904

Image size is bigger, but the build time is under reasonable limits.

```
REPOSITORY                                      TAG                 IMAGE ID            CREATED             SIZE
mike                                            latest              90628b250c16        57 seconds ago      314MB
vs
macbre/mike                                     latest              9cb9746db092        13 hours ago        177MB
b6f8eef
```