### PR TITLE
Smaller Docker image - bring back Alpine-based image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,23 @@ LABEL commit=${COMMIT}
 WORKDIR /opt/mike
 
 # install dependencies
-ADD setup.py .
-ADD mycroft_holmes/__init__.py mycroft_holmes/
-ADD mycroft_holmes/bin mycroft_holmes/bin
+COPY setup.py .
+COPY mycroft_holmes/__init__.py mycroft_holmes/
+COPY mycroft_holmes/bin mycroft_holmes/bin
 
-RUN apk add --update --no-cache mariadb-connector-c \
-    && apk add --no-cache --virtual .build-deps build-base mariadb-dev libffi-dev yaml-dev libxml2-dev libxslt-dev \
+# @see https://leemendelowitz.github.io/blog/how-does-python-find-packages.html
+# Python by default reads site packages from /usr/local/lib/python3.6/site-packages
+# while apk install py3-lxml to /usr/lib/python3.6/site-packages
+ENV PYTHONPATH /usr/local/lib/python3.6/site-packages:/usr/lib/python3.6/site-packages
+
+RUN apk add --update --no-cache mariadb-connector-c py3-lxml \
+    && apk add --no-cache --virtual .build-deps build-base mariadb-dev libffi-dev yaml-dev \
     && pip install -e . \
-    && apk del .build-deps
+    && apk del .build-deps \
+    && pip list
 
 # copy the rest of the files
-ADD . .
+COPY . .
 
 # expose the HTTP port
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.6-alpine3.9
 
 # label the image with branch name and commit hash
 LABEL maintainer="maciej.brencz@gmail.com"
@@ -14,10 +14,10 @@ ADD setup.py .
 ADD mycroft_holmes/__init__.py mycroft_holmes/
 ADD mycroft_holmes/bin mycroft_holmes/bin
 
-RUN apt-get update && apt-get install -y libmariadbclient-dev gcc \
+RUN apk add --update --no-cache mariadb-connector-c \
+    && apk add --no-cache --virtual .build-deps build-base mariadb-dev libffi-dev yaml-dev libxml2-dev libxslt-dev \
     && pip install -e . \
-    && rm -rf ~/.cache/pip \
-    && apt-get remove -y gcc && apt-get autoremove -y
+    && apk del .build-deps
 
 # copy the rest of the files
 ADD . .

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'PyAthena==1.4.4',
         'pyyaml>=4.2b1',
         'python-dotenv==0.10.1',
-        'lxml==4.3.0',
+        'lxml>=4.2.0',
         # UI
         'flask==1.0.2',
         'gunicorn==19.9.0',


### PR DESCRIPTION
* use pre-compiled lxml from Alpine packages repository: https://pkgs.alpinelinux.org/package/edge/main/x86/py3-lxml

```
Requirement already satisfied: lxml>=4.2.0 in /usr/lib/python3.6/site-packages (from mycroft-holmes==0.1) (4.2.5)
```

* point Python to dist packages along with site packages

```
Step 11/19 : ENV PYTHONPATH /usr/local/lib/python3.6/site-packages:/usr/lib/python3.6/site-packages
```

* use `COPY` instead of `ADD`

## Images size

```
REPOSITORY                  TAG                 IMAGE ID            CREATED              SIZE
mike                        latest              2571fe219757        About a minute ago   232MB
vs
mike                        latest              90628b250c16        57 seconds ago       314MB
```