### PR TITLE
DE-4380 | Report extensions usage via Mike

### DIFF
--- a/test/fixtures/config.yaml
+++ b/test/fixtures/config.yaml
@@ -91,11 +91,11 @@ metrics:
   # Editors
   - name: editor/impressions
     source: wikia/athena
-    query: 'SELECT count(*) FROM "statsdb"."fact_trackingevent_events" WHERE ga_label = ''edit-page-ready'' AND  ga_category = %(ga_category)s AND year = cast(year(now()) as VARCHAR) AND event_ts > now() - interval ''1'' day'
+    query: "SELECT count(*) FROM statsdb.fact_trackingevent_events WHERE ga_label = 'edit-page-ready' AND  ga_category = %(ga_category)s AND concat(year, month, day) = REPLACE(SUBSTR( CAST( (now() - interval '2' day) AS VARCHAR), 1, 10), '-', '')"
     label: "Editor impressions daily: %d"
   - name: editor/publishes
     source: wikia/athena
-    query: 'SELECT count(*) FROM "statsdb"."fact_trackingevent_events" WHERE ga_label = ''publish'' AND  ga_category = %(ga_category)s AND year = cast(year(now()) as VARCHAR) AND event_ts > now() - interval ''1'' day'
+    query: "SELECT count(*) FROM statsdb.fact_trackingevent_events WHERE ga_label = 'publish' AND  ga_category = %(ga_category)s AND concat(year, month, day) = REPLACE(SUBSTR( CAST( (now() - interval '2' day) AS VARCHAR), 1, 10), '-', '')"
     label: "Edits published daily: %d"
 
   # portability metrics via GA (CORE-81)
@@ -128,27 +128,27 @@ metrics:
   - name: athena/contributions_in_ns
     source: wikia/athena
     # https://prestodb.github.io/docs/0.172/functions/datetime.html
-    query: "SELECT count(*) FROM statsdb.fact_event_events WHERE year = cast(year(now()) as VARCHAR) AND event_ts > now() - interval '1' day AND event_type IN ('create', 'edit') AND namespace_id BETWEEN %(athena_ns_from)d AND %(athena_ns_to)d"
+    query: "SELECT count(*) FROM statsdb.fact_event_events WHERE concat(year, month, day) = REPLACE(SUBSTR( CAST( (now() - interval '2' day) AS VARCHAR), 1, 10), '-', '') AND event_type IN ('create', 'edit') AND namespace_id BETWEEN %(athena_ns_from)d AND %(athena_ns_to)d"
     label: "Edits in the last 24h: %d"
   - name: athena/pageviews_in_ns
     source: wikia/athena
     # https://prestodb.github.io/docs/0.172/functions/datetime.html
-    query: "SELECT count(*) FROM statsdb.fact_pageview_events WHERE year = cast(year(now()) as VARCHAR) AND event_ts > now() - interval '1' day AND namespace_id BETWEEN %(athena_ns_from)d AND %(athena_ns_to)d"
+    query: "SELECT count(*) FROM statsdb.fact_pageview_events WHERE concat(year, month, day) = REPLACE(SUBSTR( CAST( (now() - interval '2' day) AS VARCHAR), 1, 10), '-', '') AND namespace_id BETWEEN %(athena_ns_from)d AND %(athena_ns_to)d"
     label: "Page views in the last 24h: %d"
 
   - name: chat/joins
     source: wikia/athena
-    query: "SELECT count(*) FROM statsdb.fact_trackingevent_events WHERE ga_category = 'chat' and ga_label = 'message' AND year = cast(year(now()) as VARCHAR) AND event_ts > now() - interval '1' day"
+    query: "SELECT count(*) FROM statsdb.fact_trackingevent_events WHERE ga_category = 'chat' and ga_label = 'message' AND concat(year, month, day) = REPLACE(SUBSTR( CAST( (now() - interval '2' day) AS VARCHAR), 1, 10), '-', '')"
     label: "Chat joins in the last 24h: %d"
   - name: chat/messages
     source: wikia/athena
-    query: "SELECT count(*) FROM statsdb.fact_trackingevent_events WHERE ga_category = 'chat' and ga_label = 'join' AND year = cast(year(now()) as VARCHAR) AND event_ts > now() - interval '1' day"
+    query: "SELECT count(*) FROM statsdb.fact_trackingevent_events WHERE ga_category = 'chat' and ga_label = 'join' AND concat(year, month, day) = REPLACE(SUBSTR( CAST( (now() - interval '2' day) AS VARCHAR), 1, 10), '-', '')"
     label: "Chat messages in the last 24h: %d"
 
   - name: shared_help/pv
     source: wikia/athena
     # page views in NS_HELP namespace excluding community.wikia.com
-    query: "SELECT count(*) FROM statsdb.fact_pageview_events WHERE year = cast(year(now()) as VARCHAR) AND event_ts > now() - interval '1' day AND namespace_id = %(athena_ns)d  AND wiki_id <> 177 /* community */;"
+    query: "SELECT count(*) FROM statsdb.fact_pageview_events WHERE concat(year, month, day) = REPLACE(SUBSTR( CAST( (now() - interval '2' day) AS VARCHAR), 1, 10), '-', '') AND namespace_id = %(athena_ns)d  AND wiki_id <> 177 /* community */;"
     label: "Help pages views in the last 24h: %d"
 
   # HTTP sources

--- a/test/fixtures/config.yaml
+++ b/test/fixtures/config.yaml
@@ -170,6 +170,22 @@ common:
 # now features "score" will be calculated using the metrics defined above with per-feature parameters set
 features:
 
+  #
+  # Data Engineering components
+  #
+  - name: WAM
+    url: https://wikia-inc.atlassian.net/wiki/spaces/DE/pages/138543187/WAM
+    repo: https://github.com/Wikia/app/tree/dev/extensions/wikia/WAM
+    template:
+        component: "WAM"
+        ga_filter: "ga:eventCategory==wam-page;ga:eventAction==impression"
+        ga_label: "Special page PV daily"
+    metrics:
+        - name: analytics/events
+
+  #
+  # Other teams
+  #
   - name: SharedHelp
     url: http://docs.company.net/pages/SharedHelp
     repo: https://github.com/Wikia/app/tree/dev/extensions/wikia/SharedHelp


### PR DESCRIPTION
Add a WAM component - see 440fb30

And improve Athena queries performance: `run time: 15.84 seconds, Data scanned: 32.35 GB` vs `run time: 6.82 seconds, Data scanned: 256.69 MB`